### PR TITLE
Add script to automatically update README files when new translations are added

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 - [coeurGG](https://github.com/coeurGG) (French)
 - [Foxie117](https://github.com/Foxie1171) (Russian)
-- [TKMachine] (Romanian)
-- [Kyeki] (Spanish)
-- [jorgex] (Spanish)
-
+- [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## DONATE
  - PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)

--- a/README.md
+++ b/README.md
@@ -69,19 +69,10 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 - [coeurGG](https://github.com/coeurGG) (French)
 - [Foxie117](https://github.com/Foxie1171) (Russian)
-- [TKMachine] (Romanian)
-- [Kyeki] (Spanish)
-- [jorgex] (Spanish)
-
-
-## DONATE
- - PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
- - BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
- - ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
- - ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
-
-## LICENSE
- - Use of this program is offered under the [GNU GPLv3.0 License](LICENSE).
+- [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## CONTRIBUTING
  - If you have found a bug, you can help contribute by [opening an issue](https://github.com/Speyedr/socialclub-notification-blocker/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -69,10 +69,19 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 - [coeurGG](https://github.com/coeurGG) (French)
 - [Foxie117](https://github.com/Foxie1171) (Russian)
-- [TKMachine](https://github.com/TKMachine) (Romanian)
-- [Kyeki](https://github.com/Kyekii) (Spanish)
-- [jorgex](https://github.com/jorgex94) (Spanish)
-- [Rav1sh](https://github.com/Rav1sh) (Dutch)
+- [TKMachine] (Romanian)
+- [Kyeki] (Spanish)
+- [jorgex] (Spanish)
+
+
+## DONATE
+ - PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
+ - BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
+ - ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
+ - ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
+
+## LICENSE
+ - Use of this program is offered under the [GNU GPLv3.0 License](LICENSE).
 
 ## CONTRIBUTING
  - If you have found a bug, you can help contribute by [opening an issue](https://github.com/Speyedr/socialclub-notification-blocker/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md) | [Russian](translations/RU/README.md)
+English | [French](translations/FR/README.md) | [Romanian](translations/RO/README.md) | [Russian](translations/RU/README.md) | [Spanish](translations/ES/README.md)
 
 **8th of March, 2022 UPDATE: Rockstar has patched the current spectator exploit.**
 
@@ -69,6 +69,9 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 - [coeurGG](https://github.com/coeurGG) (French)
 - [Foxie117](https://github.com/Foxie1171) (Russian)
+- [TKMachine] (Romanian)
+- [Kyeki] (Spanish)
+- [jorgex] (Spanish)
 
 
 ## DONATE

--- a/translations/ES/README.md
+++ b/translations/ES/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | Spanish
+English | [French](translations/FR/README.md)
 
 **8 de marzo de 2022 ACTUALIZACION: Rockstar ha corregido el exploit del espectador.**
 
@@ -69,10 +69,15 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 - [coeurGG](https://github.com/coeurGG) (French)
 - [Foxie117](https://github.com/Foxie1171) (Russian)
-- [TKMachine](https://github.com/TKMachine) (Romanian)
-- [Kyeki](https://github.com/Kyekii) (Spanish)
-- [jorgex](https://github.com/jorgex94) (Spanish)
-- [Rav1sh](https://github.com/Rav1sh) (Dutch)
+
+## Donativos
+ - PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
+ - BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
+ - ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
+ - ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
+
+## Licencia
+ - El uso de este programa está bajo la [Licencia GNU GPLv3.0 (en inglés)](LICENSE).
 
 ## Contribuir
  - Si ha encontrado un error, puede ayudar a contribuir al [crear una publicación](https://github.com/Speyedr/socialclub-notification-blocker/issues/new/choose).

--- a/translations/ES/README.md
+++ b/translations/ES/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md)
+[English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | Spanish
 
 **8 de marzo de 2022 ACTUALIZACION: Rockstar ha corregido el exploit del espectador.**
 
@@ -69,6 +69,10 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 - [coeurGG](https://github.com/coeurGG) (French)
 - [Foxie117](https://github.com/Foxie1171) (Russian)
+- [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## Donativos
  - PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)

--- a/translations/ES/README.md
+++ b/translations/ES/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md)
+[English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | Spanish
 
 **8 de marzo de 2022 ACTUALIZACION: Rockstar ha corregido el exploit del espectador.**
 
@@ -69,15 +69,10 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 - [coeurGG](https://github.com/coeurGG) (French)
 - [Foxie117](https://github.com/Foxie1171) (Russian)
-
-## Donativos
- - PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
- - BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
- - ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
- - ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
-
-## Licencia
- - El uso de este programa está bajo la [Licencia GNU GPLv3.0 (en inglés)](LICENSE).
+- [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## Contribuir
  - Si ha encontrado un error, puede ayudar a contribuir al [crear una publicación](https://github.com/Speyedr/socialclub-notification-blocker/issues/new/choose).

--- a/translations/FR/README.md
+++ b/translations/FR/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | French | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
+[English](../../README.md) | French | [Russian](../RU/README.md)
 
 **8 Mars 2022 MISE A JOUR: Rockstar a patch le problème du spectateur mode.**
 
@@ -78,12 +78,19 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 ### Traduction / Translation
 
-- [coeurGG](https://github.com/coeurGG) (French)
-- [Foxie117](https://github.com/Foxie1171) (Russian)
-- [TKMachine](https://github.com/TKMachine) (Romanian)
-- [Kyeki](https://github.com/Kyekii) (Spanish)
-- [jorgex](https://github.com/jorgex94) (Spanish)
-- [Rav1sh](https://github.com/Rav1sh) (Dutch)
+* [coeurGG](https://github.com/coeurGG) Traduction Française | Note de Coeur : Si vous trouvez la moindre faute ou une mauvaise traduction, n'hésitez pas à me contacter sur le fork que j'ai fait.
+* [Foxie117](https://github.com/Foxie117) (Russian)
+
+## DONATE
+
+* PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
+* BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
+* ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
+* ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
+
+## LICENCE
+
+* L'utilisation de ce programme est offert sous la [Licence GNU GPLv3.0](LICENSE).
 
 ## CONTRIBUTIONS 
 

--- a/translations/FR/README.md
+++ b/translations/FR/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | French | [Russian](../RU/README.md)
+[English](../../README.md) | French | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
 
 **8 Mars 2022 MISE A JOUR: Rockstar a patch le problème du spectateur mode.**
 
@@ -78,19 +78,12 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 ### Traduction / Translation
 
-* [coeurGG](https://github.com/coeurGG) Traduction Française | Note de Coeur : Si vous trouvez la moindre faute ou une mauvaise traduction, n'hésitez pas à me contacter sur le fork que j'ai fait.
-* [Foxie117](https://github.com/Foxie117) (Russian)
-
-## DONATE
-
-* PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
-* BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
-* ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
-* ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
-
-## LICENCE
-
-* L'utilisation de ce programme est offert sous la [Licence GNU GPLv3.0](LICENSE).
+- [coeurGG](https://github.com/coeurGG) (French)
+- [Foxie117](https://github.com/Foxie1171) (Russian)
+- [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## CONTRIBUTIONS 
 

--- a/translations/FR/README.md
+++ b/translations/FR/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](././README.md) | French | [Russian](./RU/README.md)
+[English](../../README.md) | French | [Russian](../RU/README.md)
 
 **8 Mars 2022 MISE A JOUR: Rockstar a patch le problème du spectateur mode.**
 

--- a/translations/FR/README.md
+++ b/translations/FR/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | French | [Russian](../RU/README.md)
+[English](../../README.md) | French | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
 
 **8 Mars 2022 MISE A JOUR: Rockstar a patch le problème du spectateur mode.**
 
@@ -78,8 +78,12 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 ### Traduction / Translation
 
-* [coeurGG](https://github.com/coeurGG) Traduction Française | Note de Coeur : Si vous trouvez la moindre faute ou une mauvaise traduction, n'hésitez pas à me contacter sur le fork que j'ai fait.
-* [Foxie117](https://github.com/Foxie117) (Russian)
+- [coeurGG](https://github.com/coeurGG) (French)
+- [Foxie117](https://github.com/Foxie1171) (Russian)
+- [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## DONATE
 

--- a/translations/FR/README.md
+++ b/translations/FR/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md) | [Russian](translations/RU/README.md)
+[English](././README.md) | French | [Russian](./RU/README.md)
 
 **8 Mars 2022 MISE A JOUR: Rockstar a patch le problème du spectateur mode.**
 

--- a/translations/RO/README.md
+++ b/translations/RO/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md) | [Romanian](translations/RO/README.md)  
+[English](../../README.md) | [French](../FR/README.md) | Romanian | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
 
 **8 Martie, 2022 UPDATE: Rockstar a reparat exploit-ul legat de modul spectator.**
 
@@ -67,16 +67,11 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 ### Translatori
 
 - [coeurGG](https://github.com/coeurGG) (French)
+- [Foxie117](https://github.com/Foxie1171) (Russian)
 - [TKMachine](https://github.com/TKMachine) (Romanian)
-
-## DONATI
- - PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
- - BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
- - ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
- - ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
-
-## LICENȚĂ
- - Acest program este oferit sub licența [GNU GPLv3.0 License](LICENSE).
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## CONTRIBUȚIE
  - Dacă ai descoperit un bug, poți să ajuți prin [deschiderea unui tichet](https://github.com/Speyedr/socialclub-notification-blocker/issues/new/choose).

--- a/translations/RO/README.md
+++ b/translations/RO/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | [French](../FR/README.md) | Romanian | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
+English | [French](translations/FR/README.md) | [Romanian](translations/RO/README.md)  
 
 **8 Martie, 2022 UPDATE: Rockstar a reparat exploit-ul legat de modul spectator.**
 
@@ -67,11 +67,16 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 ### Translatori
 
 - [coeurGG](https://github.com/coeurGG) (French)
-- [Foxie117](https://github.com/Foxie1171) (Russian)
 - [TKMachine](https://github.com/TKMachine) (Romanian)
-- [Kyeki](https://github.com/Kyekii) (Spanish)
-- [jorgex](https://github.com/jorgex94) (Spanish)
-- [Rav1sh](https://github.com/Rav1sh) (Dutch)
+
+## DONATI
+ - PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
+ - BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
+ - ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
+ - ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
+
+## LICENȚĂ
+ - Acest program este oferit sub licența [GNU GPLv3.0 License](LICENSE).
 
 ## CONTRIBUȚIE
  - Dacă ai descoperit un bug, poți să ajuți prin [deschiderea unui tichet](https://github.com/Speyedr/socialclub-notification-blocker/issues/new/choose).

--- a/translations/RO/README.md
+++ b/translations/RO/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md) | [Romanian](translations/RO/README.md)  
+[English](../../README.md) | [French](../FR/README.md) | Romanian | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
 
 **8 Martie, 2022 UPDATE: Rockstar a reparat exploit-ul legat de modul spectator.**
 
@@ -67,7 +67,11 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 ### Translatori
 
 - [coeurGG](https://github.com/coeurGG) (French)
+- [Foxie117](https://github.com/Foxie1171) (Russian)
 - [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## DONATI
  - PayPal / Card: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)

--- a/translations/RU/README.md
+++ b/translations/RU/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md) | [Russian](translations/RU/README.md)
+[English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | Russian | [Spanish](../ES/README.md)
 
 **ОБНОВЛЕНИЕ ОТ 8 МАРТА 2022: Rockstar убрали эксплоит, позволяющий приглашать в режиме наблюдателя.**
 
@@ -68,16 +68,11 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 ### Переводчики
 
 - [coeurGG](https://github.com/coeurGG) (French)
-- [Foxie117](https://github.com/Foxie117) (Russian)
-
-## Пожертвования
- - PayPal / Карта: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
- - BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
- - ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
- - ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
-
-## Лицензирование
- - Использование этой программы предлагается в рамках [лицензии GNU GPLv3.0 ](LICENSE).
+- [Foxie117](https://github.com/Foxie1171) (Russian)
+- [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## Содействие
  - Если вы нашли ошибку, вы можете внести свой вклад, [открыв issue](https://github.com/Speyedr/socialclub-notification-blocker/issues/new/choose).

--- a/translations/RU/README.md
+++ b/translations/RU/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | Russian | [Spanish](../ES/README.md)
+English | [French](translations/FR/README.md) | [Russian](translations/RU/README.md)
 
 **ОБНОВЛЕНИЕ ОТ 8 МАРТА 2022: Rockstar убрали эксплоит, позволяющий приглашать в режиме наблюдателя.**
 
@@ -68,11 +68,16 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 ### Переводчики
 
 - [coeurGG](https://github.com/coeurGG) (French)
-- [Foxie117](https://github.com/Foxie1171) (Russian)
-- [TKMachine](https://github.com/TKMachine) (Romanian)
-- [Kyeki](https://github.com/Kyekii) (Spanish)
-- [jorgex](https://github.com/jorgex94) (Spanish)
-- [Rav1sh](https://github.com/Rav1sh) (Dutch)
+- [Foxie117](https://github.com/Foxie117) (Russian)
+
+## Пожертвования
+ - PayPal / Карта: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)
+ - BTC: `347M8sHnahA98c7MjHGmvsb5pVUJeUcMZ5`
+ - ETH: `0xDBAa338137Fc53BA007D7Cf99DD94908e8Fdb6d8`
+ - ADA: `addr1qy6xlrpv43xjwhjpdvalccjxm3tf46f5cu7uh5uhexzgwyudcmm3ty8entef6tu3dgf8chn70tc3uql0kkrj0f62mw9sxh29w3`
+
+## Лицензирование
+ - Использование этой программы предлагается в рамках [лицензии GNU GPLv3.0 ](LICENSE).
 
 ## Содействие
  - Если вы нашли ошибку, вы можете внести свой вклад, [открыв issue](https://github.com/Speyedr/socialclub-notification-blocker/issues/new/choose).

--- a/translations/RU/README.md
+++ b/translations/RU/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md) | [Russian](translations/RU/README.md)
+[English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | Russian | [Spanish](../ES/README.md)
 
 **ОБНОВЛЕНИЕ ОТ 8 МАРТА 2022: Rockstar убрали эксплоит, позволяющий приглашать в режиме наблюдателя.**
 
@@ -68,7 +68,11 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 ### Переводчики
 
 - [coeurGG](https://github.com/coeurGG) (French)
-- [Foxie117](https://github.com/Foxie117) (Russian)
+- [Foxie117](https://github.com/Foxie1171) (Russian)
+- [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
+- [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## Пожертвования
  - PayPal / Карта: [ko-fi.com/Speyedr](https://ko-fi.com/speyedr)

--- a/util/sync_readme.py
+++ b/util/sync_readme.py
@@ -1,0 +1,95 @@
+"""
+Adjusts hyperlinks and text across all readme files so that they "agree" with each other.
+
+Rather than updating files individually, this script is updated and re-run per update, which then modifies all readmes.
+
+IMPORTANT: Run this script from the base directory, NOT the util directory. e.g. `python util/sync_readme.py`
+
+Author: Daniel "Speyedr" Summer
+"""
+
+from re import compile, search
+
+class Author:
+    """Simple record-keeping class"""
+
+    def __init__(self, alias, promotional_link, language_translated):
+        self.alias = alias
+        self.url = promotional_link
+        self.language = language_translated
+
+    def __str__(self):
+        return self.get_markdown_embed()
+
+    def get_markdown_embed(self):
+        return "[" + self.alias + "](" + self.url + ") (" + self.language + ")"
+
+
+# Promotional URLs are currently just GitHub links but can be changed to any other link on request.
+TRANSLATION_CREDITS = [
+                        Author("coeurGG", "https://github.com/coeurGG", "French"),
+                        Author("Foxie117", "https://github.com/Foxie1171", "Russian"),
+                        Author("TKMachine", "https://github.com/TKMachine", "Romanian"),
+                        Author("Kyeki", "https://github.com/Kyekii", "Spanish"),
+                        Author("jorgex", "https://github.com/jorgex94", "Spanish"),
+                        Author("Rav1sh", "https://github.com/Rav1sh", "Dutch")
+                      ]
+
+# Key is ISO 639-1 language code (which is also the name of the folder), value is name of the language.
+# Is there even a need to do this? Can't we just get an ISO 639-1 library / lookup table from somewhere?
+# TODO: Search directories to figure out the ISO codes for current languages
+LANGUAGES = {
+                "EN": "English",
+                "ES": "Spanish",
+                "FR": "French",
+                "RU": "Russian",
+                "RO": "Romanian",
+                "NL": "Dutch"
+}
+
+# TRANSLATIONS.items() returns array of tuples where [0] is key (ISO 639-1 code) and [1] is value (name of language).
+# sorted() sorts an array of items based on a key, which in this case is a function which simply returns [1], the value.
+# i.e. TRANSLATIONS is now a sorted array of tuples, in ascending alphabetical order on the name of the language.
+LANGUAGES = [(key, value) for (key, value) in sorted(LANGUAGES.items(), key=lambda x: x[1])]
+
+LANGUAGE_HEADER_LINE = 2    # 3rd line in the file is where the Language header goes.
+
+# Matches all characters part of the previous credits section.
+# Find '[-*] \[coeurGG\]`
+#FIND_PREVIOUS_CREDITS =
+
+
+def get_credits_list(list_of_authors=None):
+    if list_of_authors is None:
+        list_of_authors = TRANSLATION_CREDITS
+
+    ret = ""
+    for author in list_of_authors:
+        ret += author.get_markdown_embed() + "\n"
+
+    return ret
+
+
+def generate_url_to_file(linked_readme_language, this_readme_language="EN"):
+    if linked_readme_language == this_readme_language: return "README.md"   # We're already at this file
+
+    return ("translations/" if this_readme_language == "EN" else "../") + \
+           ("../" if linked_readme_language == "EN" else linked_readme_language + "/") + \
+            "README.md"
+
+
+def get_readme_header_links(this_readme_language="EN", header_separator=" | "):
+    ret = []
+    for (iso_code, name) in LANGUAGES:
+        if name == this_readme_language:
+            ret.append(name)
+        else:
+            ret.append(generate_url_to_file(iso_code, this_readme_language))
+
+    return header_separator.join(ret)
+
+
+if __name__ == "__main__":
+    # Relative links are in the context of the base directory, which is where the English README file is.
+    files = [generate_url_to_file(iso_code, "EN") for (iso_code, name) in LANGUAGES]
+    # Read file, overwrite 3rd line (

--- a/util/sync_readme.py
+++ b/util/sync_readme.py
@@ -3,12 +3,18 @@ Adjusts hyperlinks and text across all readme files so that they "agree" with ea
 
 Rather than updating files individually, this script is updated and re-run per update, which then modifies all readmes.
 
-IMPORTANT: Run this script from the base directory, NOT the util directory. e.g. `python util/sync_readme.py`
-
 Author: Daniel "Speyedr" Summer
 """
 
 from re import compile, search
+from os import scandir, getcwd, chdir  # scandir for getting language codes, getcwd and chdir for working directory fix
+
+UTILITY_FOLDER = "\\" + "util"
+working_dir = getcwd()
+
+# directory hotfix: allows running script from inside util folder
+if working_dir.endswith(UTILITY_FOLDER):
+    chdir(working_dir[:-len(UTILITY_FOLDER)])   # Go up one folder (by trimming the utility folder from absolute path)
 
 
 class Author:
@@ -25,6 +31,8 @@ class Author:
     def get_markdown_embed(self):
         return "[" + self.alias + "](" + self.url + ") (" + self.language + ")"
 
+
+TRANSLATION_FOLDER = "translations"
 
 # Promotional URLs are currently just GitHub links but can be changed to any other link on request.
 TRANSLATION_CREDITS = [
@@ -48,6 +56,11 @@ LANGUAGES = {
                 #"NL": "Dutch"
 }
 
+LANGUAGE_FOLDERS = [file.path for file in scandir(TRANSLATION_FOLDER) if file.is_dir()]
+print(LANGUAGE_FOLDERS)
+
+LANGUAGE_CODES = [directory[len(TRANSLATION_FOLDER)+1:] for directory in LANGUAGE_FOLDERS]  # get the language codes
+
 # TRANSLATIONS.items() returns array of tuples where [0] is key (ISO 639-1 code) and [1] is value (name of language).
 # sorted() sorts an array of items based on a key, which in this case is a function which simply returns [1], the value.
 # i.e. TRANSLATIONS is now a sorted array of tuples, in ascending alphabetical order on the name of the language.
@@ -68,7 +81,7 @@ def generate_credits_list(list_of_authors=None):
     for author in list_of_authors:
         ret += author.get_markdown_embed() + "\n"
 
-    return ret
+    return ret + "\n"
 
 
 def generate_url_to_file(linked_readme_language, this_readme_language="EN"):
@@ -107,4 +120,4 @@ if __name__ == "__main__":
         content = '\n'.join(lines)           # rejoin lines for next scan as it goes across several lines
         (credits_start, credits_end) = search(FIND_CREDITS_SECTION, content).span()  # find the credits section
         content = content[:credits_start] + generate_credits_list() + content[credits_end:]  # replace with new credits
-        print(content)                       # another test print
+        #print(content)                       # another test print

--- a/util/sync_readme.py
+++ b/util/sync_readme.py
@@ -123,6 +123,6 @@ if __name__ == "__main__":
         content = content[:credits_start] + generate_credits_list() + content[credits_end:]  # replace with new credits
         print(content)                       # another test print
         # TODO: Sanity checks on edited content (e.g. make sure that credits section is found, raise Error if it isn't)
-        #handle = open(file, "w", encoding="utf-8")
-        #handle.write(content)
-        #handle.close()
+        handle = open(file, "w", encoding="utf-8")
+        handle.write(content)
+        handle.close()

--- a/util/sync_readme.py
+++ b/util/sync_readme.py
@@ -119,9 +119,10 @@ if __name__ == "__main__":
         print(lines[LANGUAGES_HEADER_LINE])  # test print
         content = '\n'.join(lines)           # rejoin lines for next scan as it goes across several lines
         (credits_start, credits_end) = search(FIND_CREDITS_SECTION, content).span()  # find the credits section
+        print(content[credits_start:credits_end])       # make sure the credits section is matched properly
         content = content[:credits_start] + generate_credits_list() + content[credits_end:]  # replace with new credits
-        print(content)                       # another test print
+        #print(content)                       # another test print
         # TODO: Sanity checks on edited content (e.g. make sure that credits section is found, raise Error if it isn't)
-        handle = open(file, "w", encoding="utf-8")
-        handle.write(content)
-        handle.close()
+        #handle = open(file, "w", encoding="utf-8")
+        #handle.write(content)
+        #handle.close()

--- a/util/sync_readme.py
+++ b/util/sync_readme.py
@@ -70,7 +70,7 @@ LANGUAGES_HEADER_LINE = 2    # 3rd line in the file is where the Language header
 
 # Matches all characters part of the credits section.
 # Find the coeurGG line, keep going until we see the next header in the README file.
-FIND_CREDITS_SECTION = compile(r"[-*] \[coeurGG](?:.|\r|\n)*(?=##)")
+FIND_CREDITS_SECTION = compile(r"[-*] \[coeurGG][^#]*(?=#)")
 
 
 def generate_credits_list(list_of_authors=None):
@@ -121,7 +121,7 @@ if __name__ == "__main__":
         (credits_start, credits_end) = search(FIND_CREDITS_SECTION, content).span()  # find the credits section
         print(content[credits_start:credits_end])       # make sure the credits section is matched properly
         content = content[:credits_start] + generate_credits_list() + content[credits_end:]  # replace with new credits
-        #print(content)                       # another test print
+        print(content)                       # another test print
         # TODO: Sanity checks on edited content (e.g. make sure that credits section is found, raise Error if it isn't)
         #handle = open(file, "w", encoding="utf-8")
         #handle.write(content)

--- a/util/sync_readme.py
+++ b/util/sync_readme.py
@@ -79,7 +79,7 @@ def generate_credits_list(list_of_authors=None):
 
     ret = ""
     for author in list_of_authors:
-        ret += author.get_markdown_embed() + "\n"
+        ret += "- " + author.get_markdown_embed() + "\n"
 
     return ret + "\n"
 
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     for (file, iso_code, name) in files:
         print(file)
         #handle = open("../translations/ES/README.md")
-        handle = open(file, "r", encoding="utf-8")            # read as bytes to prevent python from decoding "invalid bytes"
+        handle = open(file, "r", encoding="utf-8")       # read as bytes to prevent python from decoding "invalid bytes"
         content = handle.read()              # read all of it
         handle.close()
         lines = content.splitlines(False)    # split by lines
@@ -120,4 +120,8 @@ if __name__ == "__main__":
         content = '\n'.join(lines)           # rejoin lines for next scan as it goes across several lines
         (credits_start, credits_end) = search(FIND_CREDITS_SECTION, content).span()  # find the credits section
         content = content[:credits_start] + generate_credits_list() + content[credits_end:]  # replace with new credits
-        #print(content)                       # another test print
+        print(content)                       # another test print
+        # TODO: Sanity checks on edited content (e.g. make sure that credits section is found, raise Error if it isn't)
+        handle = open(file, "w", encoding="utf-8")
+        handle.write(content)
+        handle.close()


### PR DESCRIPTION
A new script, `util/sync_readmes.py` has been created, which will use regex and pattern matching to find and dynamically update the Credits section and the translation header that is listed at the top of each README.md file.

This script automatically compensates for relative directories and also fixes some broken links that were present in some of the README.md files. Now, each file should correctly link to one another, and all files should "agree" with each other, too.

This script will need to be re-run every time a new README translation is added. When I have the time, I'll see if I can get this script to trigger automatically when translation updates are merged.

The script is currently not very robust and will easily crash if README files are changed in ways which are not expected. The script is also not completely automatic _yet_: I've been very busy with studies and so haven't had the time to polish this script up to the quality I want, but it's also been almost a week since this addition was meant to be completed. So, I've decided to just get the script working and will keep manually running the script when necessary to trigger updates until the script is good enough to run automatically.