### PR TITLE
Added translation header links to Dutch README translation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md) | [Romanian](translations/RO/README.md) | [Russian](translations/RU/README.md) | [Spanish](translations/ES/README.md)
+[Dutch](translations/NL/README.md) | English | [French](translations/FR/README.md) | [Romanian](translations/RO/README.md) | [Russian](translations/RU/README.md) | [Spanish](translations/ES/README.md)
 
 **8th of March, 2022 UPDATE: Rockstar has patched the current spectator exploit.**
 

--- a/translations/ES/README.md
+++ b/translations/ES/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | Spanish
+[Dutch](../NL/README.md) | [English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | Spanish
 
 **8 de marzo de 2022 ACTUALIZACION: Rockstar ha corregido el exploit del espectador.**
 

--- a/translations/FR/README.md
+++ b/translations/FR/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | French | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
+[Dutch](../NL/README.md) | [English](../../README.md) | French | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
 
 **8 Mars 2022 MISE A JOUR: Rockstar a patch le problème du spectateur mode.**
 

--- a/translations/NL/README.md
+++ b/translations/NL/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-English | [French](translations/FR/README.md) | [Russian](translations/RU/README.md) | [Dutch](translations/NL/README.md)
+Dutch | [English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
 
 **8 maart 2022 UPDATE: Rockstar heeft de huidige toeschouwers-exploit gepatcht.**
 
@@ -73,6 +73,9 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
 
 - [coeurGG](https://github.com/coeurGG) (French)
 - [Foxie117](https://github.com/Foxie1171) (Russian)
+- [TKMachine](https://github.com/TKMachine) (Romanian)
+- [Kyeki](https://github.com/Kyekii) (Spanish)
+- [jorgex](https://github.com/jorgex94) (Spanish)
 - [Rav1sh](https://github.com/Rav1sh) (Dutch)
 
 ## DONEER
@@ -88,4 +91,3 @@ C:\Users\Speyedr\socialclub-notification-blocker> python setup.py build
  - Als je een bug hebt gevonden, kun je  bijdragen door: [een probleem te openen](https://github.com/Speyedr/socialclub-notification-blocker/issues/new/choose).
  - Pull-verzoeken zijn momenteel gesloten.
  - Onder de voorwaarden van de licentie van dit project bent u meer dan welkom om uw eigen variaties te maken gebaseerd op mijn werk, zolang u alle copyrightvermeldingen, referenties, credits behoudt en ook de licentie van deze software gebruikt bij het vrijgeven van afgeleid werk.
-

--- a/translations/RO/README.md
+++ b/translations/RO/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | [French](../FR/README.md) | Romanian | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
+[Dutch](../NL/README.md) | [English](../../README.md) | [French](../FR/README.md) | Romanian | [Russian](../RU/README.md) | [Spanish](../ES/README.md)
 
 **8 Martie, 2022 UPDATE: Rockstar a reparat exploit-ul legat de modul spectator.**
 

--- a/translations/RU/README.md
+++ b/translations/RU/README.md
@@ -1,6 +1,6 @@
 # SocialClub Notification Blocker
 
-[English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | Russian | [Spanish](../ES/README.md)
+[Dutch](../NL/README.md) | [English](../../README.md) | [French](../FR/README.md) | [Romanian](../RO/README.md) | Russian | [Spanish](../ES/README.md)
 
 **ОБНОВЛЕНИЕ ОТ 8 МАРТА 2022: Rockstar убрали эксплоит, позволяющий приглашать в режиме наблюдателя.**
 

--- a/util/sync_readme.py
+++ b/util/sync_readme.py
@@ -53,7 +53,7 @@ LANGUAGES = {
                 "FR": "French",
                 "RU": "Russian",
                 "RO": "Romanian",
-                #"NL": "Dutch"
+                "NL": "Dutch"
 }
 
 LANGUAGE_FOLDERS = [file.path for file in scandir(TRANSLATION_FOLDER) if file.is_dir()]


### PR DESCRIPTION
Just noticed that the relative link for the LICENSE file is broken on translated READMEs. Will have to fix that at some point.